### PR TITLE
Fix pipelibe issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x, 18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          run_install: false
 
       - name: Install
         run: pnpm i

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          run_install: false
 
       - run: pnpm i
       - run: pnpm build

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,10 @@ function parseArgs(args: string[]): Record<string, string | boolean> {
       const k = a.slice(2);
       const next = args[i + 1];
       if (!next || next.startsWith("--")) out[k] = true;
-      else { out[k] = next; i++; }
+      else {
+        out[k] = next;
+        i++;
+      }
     }
   }
   return out;
@@ -26,7 +29,7 @@ async function readInput(fromFile?: string): Promise<string> {
   const chunks: string[] = [];
   return await new Promise((resolve, reject) => {
     process.stdin.setEncoding("utf8");
-    process.stdin.on("data", c => chunks.push(String(c)));
+    process.stdin.on("data", (c) => chunks.push(String(c)));
     process.stdin.on("end", () => resolve(chunks.join("")));
     process.stdin.on("error", reject);
   });
@@ -56,7 +59,10 @@ Example:
 
 (async function main() {
   const argv = parseArgs(process.argv.slice(2));
-  if (argv.help) { help(); process.exit(0); }
+  if (argv.help) {
+    help();
+    process.exit(0);
+  }
 
   const rootDir = path.resolve(String(argv.root ?? "."));
   const inferRoot = Boolean(argv["infer-root"]);
@@ -74,7 +80,9 @@ Example:
   try {
     const { plan, baseRoot } = parseToPlan(input, { rootDir, inferRoot });
     await executePlan(plan, { dryRun, verbose, gitkeep });
-    const msg = dryRun ? "Dry run complete. Nothing was created." : `Structure created at: ${baseRoot}`;
+    const msg = dryRun
+      ? "Dry run complete. Nothing was created."
+      : `Structure created at: ${baseRoot}`;
     process.stdout.write(msg + "\n");
   } catch (e: any) {
     process.stderr.write(`[error] ${e?.message ?? String(e)}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,12 +20,13 @@ function parseArgs(args: string[]): Record<string, string | boolean> {
 
 async function readInput(fromFile?: string): Promise<string> {
   if (fromFile) {
-    return await fs.readFile(fromFile, { encoding: "utf8" });
+    const buf = await fs.readFile(fromFile);
+    return buf.toString("utf8");
   }
   const chunks: string[] = [];
   return await new Promise((resolve, reject) => {
     process.stdin.setEncoding("utf8");
-    process.stdin.on("data", c => chunks.push(c));
+    process.stdin.on("data", c => chunks.push(String(c)));
     process.stdin.on("end", () => resolve(chunks.join("")));
     process.stdin.on("error", reject);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,9 @@ function parseArgs(args: string[]): Record<string, string | boolean> {
 }
 
 async function readInput(fromFile?: string): Promise<string> {
-  if (fromFile) return await fs.readFile(fromFile, "utf8");
+  if (fromFile) {
+    return await fs.readFile(fromFile, { encoding: "utf8" });
+  }
   const chunks: string[] = [];
   return await new Promise((resolve, reject) => {
     process.stdin.setEncoding("utf8");

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,15 @@
 import path from "node:path";
 import { PlanItem, ParseOptions } from "./types.js";
-import { computeDepth, hasExtension, isBareKnownFile, looksLikeDirToken, safeJoin, splitPrefixContent, stripBullets, stripTrailingComments } from "./utils.js";
+import {
+  computeDepth,
+  hasExtension,
+  isBareKnownFile,
+  looksLikeDirToken,
+  safeJoin,
+  splitPrefixContent,
+  stripBullets,
+  stripTrailingComments,
+} from "./utils.js";
 
 export interface ParseResult {
   plan: PlanItem[];
@@ -9,17 +18,23 @@ export interface ParseResult {
 
 export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
   const rootDir = path.resolve(opts.rootDir);
-  let lines = input.split(/\r?\n/)
-    .map(l => l.replace(/\t/g, "    "))
-    .map(l => l.replace(/\s+$/, ""))
-    .filter(l => l.trim().length > 0);
 
+  let lines = input
+    .split(/\r?\n/)
+    .map((l) => l.replace(/\t/g, "    "))
+    .map((l) => l.replace(/\s+$/, ""))
+    .filter((l) => l.trim().length > 0);
+
+  // inferRoot: primeira linha é algo como "my-project/" (apenas a barra de fechamento)
   let baseRoot = rootDir;
-  if (opts.inferRoot) {
+  if (opts.inferRoot && lines.length > 0) {
     const firstContent = sanitizeContent(lines[0]);
-    if (!firstContent.includes("/") && firstContent.endsWith("/")) {
-      baseRoot = safeJoin(rootDir, firstContent.slice(0, -1));
-      lines = lines.slice(1);
+    if (firstContent.endsWith("/")) {
+      const token = firstContent.replace(/\/+$/, "");
+      if (!token.includes("/")) {
+        baseRoot = safeJoin(rootDir, token);
+        lines = lines.slice(1);
+      }
     }
   }
 
@@ -28,18 +43,23 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
   const stack: string[] = [];
   stack[0] = baseRoot;
 
+  // garanta que o diretório baseRoot apareça no plano
+  addDir(baseRoot);
+
   for (const raw of lines) {
     const { prefix, content: unclean } = splitPrefixContent(raw);
     const depth = computeDepth(prefix);
     const content0 = sanitizeContent(unclean);
     if (!content0) continue;
 
+    // caminho absoluto relativo ao baseRoot: "/foo/bar"
     if (content0.startsWith("/")) {
       const rel = content0.replace(/^\/+/, "");
       addAny(rel, 0);
       continue;
     }
 
+    // possui separadores
     if (content0.includes("/")) {
       const isDir = content0.endsWith("/");
       const rel = isDir ? content0.slice(0, -1) : content0;
@@ -57,6 +77,7 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
       continue;
     }
 
+    // token "nu" sem barra
     if (looksLikeDirToken(content0)) {
       const parent = stack[depth] ?? baseRoot;
       const abs = safeJoin(parent, content0.replace(/\/$/, ""));
@@ -75,7 +96,7 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
   function sanitizeContent(s: string): string {
     let out = s.trim();
     out = stripBullets(out);
-    out = out.replace(/^(?:[│├└]?[─\-])\s*/, "");
+    out = out.replace(/^(?:[│├└]?[─-])\s*/, "");
     out = stripTrailingComments(out);
     out = out.trim();
     out = out.replace(/\/\s+$/, "/");
@@ -84,7 +105,9 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
   }
 
   function addAny(rel: string, depth: number) {
-    const isDir = rel.endsWith("/") || (!hasExtension(path.basename(rel)) && !isBareKnownFile(path.basename(rel)));
+    const isDir =
+      rel.endsWith("/") ||
+      (!hasExtension(path.basename(rel)) && !isBareKnownFile(path.basename(rel)));
     const abs = safeJoin(baseRoot, rel.replace(/\/$/, ""));
     if (isDir) {
       addDir(abs);
@@ -104,6 +127,7 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
       plan.push({ kind: "dir", absPath: abs });
     }
   }
+
   function addFile(abs: string) {
     const key = `f:${abs}`;
     if (!seen.has(key)) {
@@ -112,6 +136,13 @@ export function parseToPlan(input: string, opts: ParseOptions): ParseResult {
     }
   }
 
-  plan.sort((a, b) => a.kind === b.kind ? a.absPath.localeCompare(b.absPath) : (a.kind === "dir" ? -1 : 1));
+  plan.sort((a, b) =>
+    a.kind === b.kind
+      ? a.absPath.localeCompare(b.absPath)
+      : a.kind === "dir"
+      ? -1
+      : 1
+  );
+
   return { plan, baseRoot };
 }


### PR DESCRIPTION
This pull request introduces improvements to both the CLI and the parsing logic, as well as minor workflow updates. The main focus is on making the parser more robust and accurate in handling directory structures, especially when inferring root directories and handling various input formats. Additionally, the code has been refactored for better readability and maintainability.

**Parser improvements and refactoring:**

* Enhanced the `parseToPlan` function in `src/parser.ts` to more robustly infer the base root directory from the first line, ensure all ancestor directories are included in the plan, and improve handling of directory tokens and branch markers. Also, a custom `computeDepth` function was added for more accurate depth calculation. [[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL12-R63) [[2]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL78-R132) [[3]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR146-R167) [[4]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL115-R183)
* Refactored code formatting and imports in `src/parser.ts` for clarity and maintainability.

**CLI improvements:**

* Improved file reading logic and argument parsing in `src/cli.ts` to handle input more safely and robustly, and made minor formatting adjustments for readability. [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL15-R32) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL56-R65) [[3]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL74-R85)

**Workflow configuration updates:**

* Updated `.github/workflows/ci.yml` and `.github/workflows/publish.yml` to simplify Node.js version selection (now fixed at 20.x) and adjust the `pnpm` setup step for consistency. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL12-R24) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L24-R24)