### PR TITLE
update CI workflows and README badges for improved clarity

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ dev ]
   pull_request:
-    branches: [ dev ]
+    branches: [ dev ]   # PRs cujo destino é dev
 
 concurrency:
   group: ci-dev-${{ github.ref }}
@@ -16,15 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
-
       - run: pnpm i
       - run: pnpm build
       - run: pnpm test

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main ]  # PRs cujo destino é main
+  workflow_dispatch: {} # opcional: permite rodar manualmente
 
 concurrency:
   group: ci-main-${{ github.ref }}
@@ -16,15 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
-
       - run: pnpm i
       - run: pnpm build
       - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Struct Forge
-[![Build dev](https://github.com/aecoder-br/structforge/actions/workflows/ci-dev.yml/badge.svg?branch=dev)](https://github.com/aecoder-br/structforge/actions/workflows/ci-dev.yml)
-[![Build main](https://github.com/aecoder-br/structforge/actions/workflows/ci-main.yml/badge.svg?branch=main)](https://github.com/aecoder-br/structforge/actions/workflows/ci-main.yml)
+[![Build dev](https://github.com/aecoder-br/structforge/actions/workflows/ci-dev.yml/badge.svg)](https://github.com/aecoder-br/structforge/actions/workflows/ci-dev.yml)
+[![Build main](https://github.com/aecoder-br/structforge/actions/workflows/ci-main.yml/badge.svg)](https://github.com/aecoder-br/structforge/actions/workflows/ci-main.yml)
 [![License](https://img.shields.io/github/license/aecoder-br/structforge.svg)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/aecoder-br/structforge.svg?style=social)](https://github.com/aecoder-br/structforge)
 [![Node >=18](https://img.shields.io/badge/node-%3E%3D18-339933.svg)](https://nodejs.org/)


### PR DESCRIPTION
This pull request updates the CI workflow configuration and improves the project badges in the `README.md`. The main changes clarify workflow triggers, add manual workflow support, and simplify badge links.

CI workflow improvements:

* Added comments to `pull_request` triggers in `.github/workflows/ci-dev.yml` and `.github/workflows/ci-main.yml` for clarity, specifying that PRs must target `dev` or `main` respectively. [[1]](diffhunk://#diff-d03bd599ecfcd78552ac6c5d20bc8d8df8addffc99518f2b468c9b1043f95708L7-R7) [[2]](diffhunk://#diff-a1a3cb9bdeb5541d148091d973cf266aa3b317e6415a86630e816cbe27cf8b9cL7-R8)
* Enabled manual triggering of the main CI workflow by adding `workflow_dispatch` to `.github/workflows/ci-main.yml`.
* Cleaned up workflow job steps in both CI files by removing extra blank lines for better readability. [[1]](diffhunk://#diff-d03bd599ecfcd78552ac6c5d20bc8d8df8addffc99518f2b468c9b1043f95708L19-L27) [[2]](diffhunk://#diff-a1a3cb9bdeb5541d148091d973cf266aa3b317e6415a86630e816cbe27cf8b9cL19-L27)

Documentation update:

* Simplified the CI badge URLs in `README.md` by removing the explicit branch query, making the badges always reflect the latest workflow status.